### PR TITLE
feat/custom render support

### DIFF
--- a/examples/custom-render/README.md
+++ b/examples/custom-render/README.md
@@ -1,0 +1,3 @@
+An example that shows how to use decorators with a custom render component.
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/ocavue/astrobook/tree/master/examples/custom-render)

--- a/examples/custom-render/astro.config.ts
+++ b/examples/custom-render/astro.config.ts
@@ -1,0 +1,15 @@
+import preact from '@astrojs/preact'
+import { defineConfig } from 'astro/config'
+import astrobook from 'astrobook'
+
+// https://astro.build/config
+export default defineConfig({
+  server: {
+    port: 4306,
+  },
+
+  integrations: [
+    preact(),
+    astrobook({ directory: 'src/stories', subpath: '/docs/components' }),
+  ],
+})

--- a/examples/custom-render/package.json
+++ b/examples/custom-render/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@astrojs/preact": "^4.1.0",
-    "astro": "^5.11.0",
+    "astro": "^5.12.3",
     "astrobook": "*",
     "preact": "^10.26.9"
   },

--- a/examples/custom-render/package.json
+++ b/examples/custom-render/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "example-custom-render",
+  "type": "module",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Astrobook example",
+  "scripts": {
+    "dev": "astro dev",
+    "start": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "astro": "astro"
+  },
+  "dependencies": {
+    "@astrojs/preact": "^4.1.0",
+    "astro": "^5.11.0",
+    "astrobook": "*",
+    "preact": "^10.26.9"
+  },
+  "stackblitz": {
+    "installDependencies": false,
+    "startCommand": "pnpm install && pnpm run dev"
+  }
+}

--- a/examples/custom-render/src/components/Card.astro
+++ b/examples/custom-render/src/components/Card.astro
@@ -1,0 +1,61 @@
+---
+interface Props {
+  title: string
+  body: string
+  href: string
+}
+
+const { href, title, body } = Astro.props
+---
+
+<li class="link-card">
+  <a href={href}>
+    <h2>
+      {title}
+      <span>&rarr;</span>
+    </h2>
+    <p>
+      {body}
+    </p>
+  </a>
+</li>
+<style>
+  .link-card {
+    list-style: none;
+    display: flex;
+    padding: 1px;
+    background-color: #23262d;
+    background-image: none;
+    background-size: 400%;
+    border-radius: 7px;
+    background-position: 100%;
+    transition: background-position 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+  }
+  .link-card > a {
+    width: 100%;
+    text-decoration: none;
+    line-height: 1.4;
+    padding: calc(1.5rem - 1px);
+    border-radius: 8px;
+    color: white;
+    background-color: #23262d;
+    opacity: 0.8;
+  }
+  h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    transition: color 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  p {
+    margin-top: 0.5rem;
+    margin-bottom: 0;
+  }
+  .link-card:is(:hover, :focus-within) {
+    background-position: 0;
+    background-image: var(--accent-gradient);
+  }
+  .link-card:is(:hover, :focus-within) h2 {
+    color: rgb(var(--accent-light));
+  }
+</style>

--- a/examples/custom-render/src/env.d.ts
+++ b/examples/custom-render/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../.astro/types.d.ts" />

--- a/examples/custom-render/src/layouts/Layout.astro
+++ b/examples/custom-render/src/layouts/Layout.astro
@@ -1,0 +1,50 @@
+---
+interface Props {
+  title: string
+}
+
+const { title } = Astro.props
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="description" content="Astro description" />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="generator" content={Astro.generator} />
+    <title>{title}</title>
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>
+<style is:global>
+  :root {
+    --accent: 136, 58, 234;
+    --accent-light: 224, 204, 250;
+    --accent-dark: 49, 10, 101;
+    --accent-gradient: linear-gradient(
+      45deg,
+      rgb(var(--accent)),
+      rgb(var(--accent-light)) 30%,
+      white 60%
+    );
+  }
+  html {
+    font-family: system-ui, sans-serif;
+    background: #13151a;
+  }
+  code {
+    font-family:
+      Menlo,
+      Monaco,
+      Lucida Console,
+      Liberation Mono,
+      DejaVu Sans Mono,
+      Bitstream Vera Sans Mono,
+      Courier New,
+      monospace;
+  }
+</style>

--- a/examples/custom-render/src/pages/index.astro
+++ b/examples/custom-render/src/pages/index.astro
@@ -1,0 +1,111 @@
+---
+import Layout from '../layouts/Layout.astro'
+import Card from '../components/Card.astro'
+---
+
+<Layout title="Welcome to Astro.">
+  <main>
+    <svg
+      class="astro-a"
+      width="495"
+      height="623"
+      viewBox="0 0 495 623"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M167.19 364.254C83.4786 364.254 0 404.819 0 404.819C0 404.819 141.781 19.4876 142.087 18.7291C146.434 7.33701 153.027 0 162.289 0H332.441C341.703 0 348.574 7.33701 352.643 18.7291C352.92 19.5022 494.716 404.819 494.716 404.819C494.716 404.819 426.67 364.254 327.525 364.254L264.41 169.408C262.047 159.985 255.147 153.581 247.358 153.581C239.569 153.581 232.669 159.985 230.306 169.408L167.19 364.254ZM160.869 530.172C160.877 530.18 160.885 530.187 160.894 530.195L160.867 530.181C160.868 530.178 160.868 530.175 160.869 530.172ZM136.218 411.348C124.476 450.467 132.698 504.458 160.869 530.172C160.997 529.696 161.125 529.242 161.248 528.804C161.502 527.907 161.737 527.073 161.917 526.233C165.446 509.895 178.754 499.52 195.577 500.01C211.969 500.487 220.67 508.765 223.202 527.254C224.141 534.12 224.23 541.131 224.319 548.105C224.328 548.834 224.337 549.563 224.347 550.291C224.563 566.098 228.657 580.707 237.264 593.914C245.413 606.426 256.108 615.943 270.749 622.478C270.593 621.952 270.463 621.508 270.35 621.126C270.045 620.086 269.872 619.499 269.685 618.911C258.909 585.935 266.668 563.266 295.344 543.933C298.254 541.971 301.187 540.041 304.12 538.112C310.591 533.854 317.059 529.599 323.279 525.007C345.88 508.329 360.09 486.327 363.431 457.844C364.805 446.148 363.781 434.657 359.848 423.275C358.176 424.287 356.587 425.295 355.042 426.275C351.744 428.366 348.647 430.33 345.382 431.934C303.466 452.507 259.152 455.053 214.03 448.245C184.802 443.834 156.584 436.019 136.218 411.348Z"
+        fill="url(#paint0_linear_1805_24383)"></path>
+      <defs>
+        <linearGradient
+          id="paint0_linear_1805_24383"
+          x1="247.358"
+          y1="0"
+          x2="247.358"
+          y2="622.479"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stop-opacity="0.9"></stop>
+          <stop offset="1" stop-opacity="0.2"></stop>
+        </linearGradient>
+      </defs>
+    </svg>
+    <h1>Welcome to <span class="text-gradient">Astro</span></h1>
+    <p class="instructions">
+      This is an example of an Astro project that includes Astrobook under a
+      subpath.
+    </p>
+    <ul role="list" class="link-card-grid">
+      <Card
+        href="/base/docs/components"
+        title="Astrobook"
+        body="Go to Astrobook"
+      />
+    </ul>
+  </main>
+</Layout>
+
+<style>
+  main {
+    margin: auto;
+    padding: 1rem;
+    width: 800px;
+    max-width: calc(100% - 2rem);
+    color: white;
+    font-size: 20px;
+    line-height: 1.6;
+  }
+  .astro-a {
+    position: absolute;
+    top: -32px;
+    left: 50%;
+    transform: translatex(-50%);
+    width: 220px;
+    height: auto;
+    z-index: -1;
+  }
+  h1 {
+    font-size: 4rem;
+    font-weight: 700;
+    line-height: 1;
+    text-align: center;
+    margin-bottom: 1em;
+  }
+  .text-gradient {
+    background-image: var(--accent-gradient);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-size: 400%;
+    background-position: 0%;
+  }
+  .instructions {
+    margin-bottom: 2rem;
+    border: 1px solid rgba(var(--accent-light), 25%);
+    background: linear-gradient(
+      rgba(var(--accent-dark), 66%),
+      rgba(var(--accent-dark), 33%)
+    );
+    padding: 1.5rem;
+    border-radius: 8px;
+  }
+  .instructions code {
+    font-size: 0.8em;
+    font-weight: bold;
+    background: rgba(var(--accent-light), 12%);
+    color: rgb(var(--accent-light));
+    border-radius: 4px;
+    padding: 0.3em 0.4em;
+  }
+  .instructions strong {
+    color: rgb(var(--accent-light));
+  }
+  .link-card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(24ch, 1fr));
+    gap: 2rem;
+    padding: 0;
+  }
+</style>

--- a/examples/custom-render/src/stories/PreactCounter.stories.ts
+++ b/examples/custom-render/src/stories/PreactCounter.stories.ts
@@ -1,0 +1,15 @@
+import { PreactCounter, type PreactCounterProps } from './PreactCounter'
+
+export default {
+  component: PreactCounter,
+}
+
+export const Default = {
+  args: {} satisfies PreactCounterProps,
+}
+
+export const LargeStep = {
+  args: {
+    step: 5,
+  } satisfies PreactCounterProps,
+}

--- a/examples/custom-render/src/stories/PreactCounter.tsx
+++ b/examples/custom-render/src/stories/PreactCounter.tsx
@@ -1,0 +1,29 @@
+/** @jsxImportSource preact */
+
+import '../styles/global.css'
+
+import type { ComponentChildren } from 'preact'
+import { useState } from 'preact/hooks'
+
+export interface PreactCounterProps {
+  step?: number
+  children?: ComponentChildren
+}
+
+/** A counter written with Preact */
+export function PreactCounter({ step = 1, children }: PreactCounterProps) {
+  const [count, setCount] = useState(0)
+  const add = () => setCount((i) => i + step)
+  const subtract = () => setCount((i) => i - step)
+
+  return (
+    <>
+      <div class="counter">
+        <button onClick={subtract}>-</button>
+        <pre>{count}</pre>
+        <button onClick={add}>+</button>
+      </div>
+      <div class="counter-message">{children}</div>
+    </>
+  )
+}

--- a/examples/custom-render/src/styles/global.css
+++ b/examples/custom-render/src/styles/global.css
@@ -1,0 +1,11 @@
+.counter {
+  display: grid;
+  font-size: 2em;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 2em;
+  place-items: center;
+}
+
+.counter-message {
+  text-align: center;
+}

--- a/examples/custom-render/tsconfig.json
+++ b/examples/custom-render/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "lib": ["esnext"],
+    "jsx": "react-jsx",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "outDir": "${configDir}/node_modules/.cache/tsc",
+    "strict": true,
+    "allowJs": true,
+    "composite": true,
+    "strictNullChecks": true,
+    "verbatimModuleSyntax": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
+    "jsxImportSource": "preact"
+  },
+  "include": ["./src", "./*.js", "./*.mjs", "./*.ts"]
+}

--- a/examples/playground/src/components/preact/ClientJsxDecorator.tsx
+++ b/examples/playground/src/components/preact/ClientJsxDecorator.tsx
@@ -1,0 +1,17 @@
+/** @jsxImportSource preact */
+
+import type { ComponentChildren } from 'preact'
+
+export interface PreactDecoratorProps {
+  children?: ComponentChildren
+}
+
+export default function BlueBorderDecorator({ children }: PreactDecoratorProps) {
+  return (
+    <>
+      <div style="border: solid 2px blue;" data-decorator-type="jsx">
+        {children}
+      </div>
+    </>
+  )
+}

--- a/examples/playground/src/components/preact/ClientJsxDecorator.tsx
+++ b/examples/playground/src/components/preact/ClientJsxDecorator.tsx
@@ -6,7 +6,9 @@ export interface PreactDecoratorProps {
   children?: ComponentChildren
 }
 
-export default function BlueBorderDecorator({ children }: PreactDecoratorProps) {
+export default function BlueBorderDecorator({
+  children,
+}: PreactDecoratorProps) {
   return (
     <>
       <div style="border: solid 2px blue;" data-decorator-type="jsx">

--- a/examples/playground/src/components/preact/PreactCounter.stories.ts
+++ b/examples/playground/src/components/preact/PreactCounter.stories.ts
@@ -1,7 +1,7 @@
 import { GreenBorderDecorator } from '../decorators/JsxDecorator'
 import RedBorderDecorator from '../decorators/RedBorderDecorator.astro'
-import BlueBorderDecorator from './ClientJsxDecorator'
 
+import BlueBorderDecorator from './ClientJsxDecorator'
 import { PreactCounter, type PreactCounterProps } from './PreactCounter'
 
 export default {
@@ -22,10 +22,7 @@ export const RedBorder = {
   args: {
     step: 1,
   } satisfies PreactCounterProps,
-  decorators: [() => GreenBorderDecorator],
-  render: {
-    component: BlueBorderDecorator
-  }
+  decorators: [() => RedBorderDecorator],
 }
 
 export const GreenBorder = {
@@ -33,4 +30,7 @@ export const GreenBorder = {
     step: 1,
   } satisfies PreactCounterProps,
   decorators: [() => GreenBorderDecorator],
+  render: {
+    component: BlueBorderDecorator,
+  },
 }

--- a/examples/playground/src/components/preact/PreactCounter.stories.ts
+++ b/examples/playground/src/components/preact/PreactCounter.stories.ts
@@ -1,5 +1,6 @@
 import { GreenBorderDecorator } from '../decorators/JsxDecorator'
 import RedBorderDecorator from '../decorators/RedBorderDecorator.astro'
+import BlueBorderDecorator from './ClientJsxDecorator'
 
 import { PreactCounter, type PreactCounterProps } from './PreactCounter'
 
@@ -21,7 +22,10 @@ export const RedBorder = {
   args: {
     step: 1,
   } satisfies PreactCounterProps,
-  decorators: [() => RedBorderDecorator],
+  decorators: [() => GreenBorderDecorator],
+  render: {
+    component: BlueBorderDecorator
+  }
 }
 
 export const GreenBorder = {

--- a/packages/astrobook/README.md
+++ b/packages/astrobook/README.md
@@ -121,6 +121,7 @@ export function GreenBorderDecorator({ children }: PreactDecoratorProps) {
 ```
 
 And this Astro example:
+
 ```astro
 <div style="border: solid 2px red;">
   <slot />

--- a/packages/astrobook/README.md
+++ b/packages/astrobook/README.md
@@ -121,7 +121,6 @@ export function GreenBorderDecorator({ children }: PreactDecoratorProps) {
 ```
 
 And this Astro example:
-
 ```astro
 <div style="border: solid 2px red;">
   <slot />

--- a/packages/core/src/virtual-module/virtual-routes.ts
+++ b/packages/core/src/virtual-module/virtual-routes.ts
@@ -88,18 +88,51 @@ const isAstro = isAstroStory(m)
 
 <StoryPage story={'${route.props.story}'} hasSidebar={${route.props.hasSidebar}}>
   {
-    (({...m['${route.story.name}']}?.decorators || []).slice().reverse().reduce((currentTree, decoratorFn) => {
-      const Decorator = decoratorFn()
+    ([m['${route.story.name}']?.render].map(F => {
+      return F !== undefined 
+        ? isAstro
+          ? (<F>
+              {
+                ((m['${route.story.name}']?.decorators || []).slice().reverse().reduce((currentTree, decoratorFn) => {
+                  const Decorator = decoratorFn()
 
-      return (
-          <Decorator>
-            {currentTree}
-          </Decorator>
-        )
-    }, isAstro
-      ? (<m.default.component { ...m['${route.story.name}']?.args } />)
-      : (<m.default.component { ...m['${route.story.name}']?.args } client:load />)
-    ))
+                  return (
+                      <Decorator>
+                        {currentTree}
+                      </Decorator>
+                    )
+                  }, (<m.default.component { ...m['${route.story.name}']?.args } />)
+                ))
+              }
+          </F>)
+          : (<F client:load>
+              {
+                ((m['${route.story.name}']?.decorators || []).slice().reverse().reduce((currentTree, decoratorFn) => {
+                  const Decorator = decoratorFn()
+
+                  return (
+                      <Decorator>
+                        {currentTree}
+                      </Decorator>
+                    )
+                  }, (<m.default.component { ...m['${route.story.name}']?.args } />)
+                ))
+              }
+          </F>)
+        : (({...m['${route.story.name}']}?.decorators || []).slice().reverse().reduce((currentTree, decoratorFn) => {
+              const Decorator = decoratorFn()
+
+              return (
+                  <Decorator>
+                    {currentTree}
+                  </Decorator>
+                )
+            }, isAstro
+              ? (<m.default.component { ...m['${route.story.name}']?.args } />)
+              : (<m.default.component { ...m['${route.story.name}']?.args } client:load />)
+            )
+          )
+      }))
   }
 </StoryPage>
 `.trim()

--- a/packages/core/src/virtual-module/virtual-routes.ts
+++ b/packages/core/src/virtual-module/virtual-routes.ts
@@ -88,10 +88,10 @@ const isAstro = isAstroStory(m)
 
 <StoryPage story={'${route.props.story}'} hasSidebar={${route.props.hasSidebar}}>
   {
-    ([m['${route.story.name}']?.render].map(F => {
-      return F !== undefined 
+    ([m['${route.story.name}']?.render].map(Render => {
+      return Render !== undefined 
         ? isAstro
-          ? (<F>
+          ? (<Render.component { ...Render.props }>
               {
                 ((m['${route.story.name}']?.decorators || []).slice().reverse().reduce((currentTree, decoratorFn) => {
                   const Decorator = decoratorFn()
@@ -104,8 +104,8 @@ const isAstro = isAstroStory(m)
                   }, (<m.default.component { ...m['${route.story.name}']?.args } />)
                 ))
               }
-          </F>)
-          : (<F client:load>
+          </Render>)
+          : (<Render.component { ...Render.props } client:load>
               {
                 ((m['${route.story.name}']?.decorators || []).slice().reverse().reduce((currentTree, decoratorFn) => {
                   const Decorator = decoratorFn()
@@ -118,7 +118,7 @@ const isAstro = isAstroStory(m)
                   }, (<m.default.component { ...m['${route.story.name}']?.args } />)
                 ))
               }
-          </F>)
+          </Render>)
         : (({...m['${route.story.name}']}?.decorators || []).slice().reverse().reduce((currentTree, decoratorFn) => {
               const Decorator = decoratorFn()
 

--- a/packages/core/src/virtual-module/virtual-routes.ts
+++ b/packages/core/src/virtual-module/virtual-routes.ts
@@ -91,7 +91,7 @@ const isAstro = isAstroStory(m)
     ([m['${route.story.name}']?.render].map(Render => {
       return Render !== undefined 
         ? isAstro
-          ? (<Render.component { ...Render.props }>
+          ? (<m.${route.story.name}.render.component>
               {
                 ((m['${route.story.name}']?.decorators || []).slice().reverse().reduce((currentTree, decoratorFn) => {
                   const Decorator = decoratorFn()
@@ -104,8 +104,8 @@ const isAstro = isAstroStory(m)
                   }, (<m.default.component { ...m['${route.story.name}']?.args } />)
                 ))
               }
-          </Render>)
-          : (<Render.component { ...Render.props } client:load>
+          </m.${route.story.name}.render.component>)
+          : (<m.${route.story.name}.render.component client:load>
               {
                 ((m['${route.story.name}']?.decorators || []).slice().reverse().reduce((currentTree, decoratorFn) => {
                   const Decorator = decoratorFn()
@@ -118,20 +118,24 @@ const isAstro = isAstroStory(m)
                   }, (<m.default.component { ...m['${route.story.name}']?.args } />)
                 ))
               }
-          </Render>)
-        : (({...m['${route.story.name}']}?.decorators || []).slice().reverse().reduce((currentTree, decoratorFn) => {
-              const Decorator = decoratorFn()
+          </m.${route.story.name}.render.component>)
+        : (<>
+            {
+              ((m['${route.story.name}']?.decorators || []).slice().reverse().reduce((currentTree, decoratorFn) => {
+                  const Decorator = decoratorFn()
 
-              return (
-                  <Decorator>
-                    {currentTree}
-                  </Decorator>
+                  return (
+                      <Decorator>
+                        {currentTree}
+                      </Decorator>
+                    )
+                }, isAstro
+                  ? (<m.default.component { ...m['${route.story.name}']?.args } />)
+                  : (<m.default.component { ...m['${route.story.name}']?.args } client:load />)
                 )
-            }, isAstro
-              ? (<m.default.component { ...m['${route.story.name}']?.args } />)
-              : (<m.default.component { ...m['${route.story.name}']?.args } client:load />)
-            )
-          )
+              )
+            }
+          </>)
       }))
   }
 </StoryPage>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,21 @@ importers:
         specifier: workspace:*
         version: link:../../packages/astrobook
 
+  examples/custom-render:
+    dependencies:
+      '@astrojs/preact':
+        specifier: ^4.1.0
+        version: 4.1.0(@babel/core@7.27.1)(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(preact@10.26.9)(tsx@4.20.3)
+      astro:
+        specifier: ^5.11.0
+        version: 5.12.3(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.41.0)(tsx@4.20.3)(typescript@5.8.3)
+      astrobook:
+        specifier: workspace:*
+        version: link:../../packages/astrobook
+      preact:
+        specifier: ^10.26.9
+        version: 10.26.9
+
   examples/mixed:
     dependencies:
       '@astrojs/preact':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,7 +75,7 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@babel/core@7.27.1)(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(preact@10.26.9)(tsx@4.20.3)
       astro:
-        specifier: ^5.11.0
+        specifier: ^5.12.3
         version: 5.12.3(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.41.0)(tsx@4.20.3)(typescript@5.8.3)
       astrobook:
         specifier: workspace:*

--- a/tests/example-urls.js
+++ b/tests/example-urls.js
@@ -5,5 +5,5 @@ export const EXAMPLE_URLS = /** @type {const} */ ({
   'example-unocss': 'http://localhost:4303',
   'example-tailwindcss': 'http://localhost:4304',
   'example-pandacss': 'http://localhost:4309',
-  'example-custom-render': 'http://localhost:4306'
+  'example-custom-render': 'http://localhost:4306',
 })

--- a/tests/example-urls.js
+++ b/tests/example-urls.js
@@ -5,4 +5,5 @@ export const EXAMPLE_URLS = /** @type {const} */ ({
   'example-unocss': 'http://localhost:4303',
   'example-tailwindcss': 'http://localhost:4304',
   'example-pandacss': 'http://localhost:4309',
+  'example-custom-render': 'http://localhost:4306'
 })


### PR DESCRIPTION
## Changelog

- Allow stories to have custom render components

## Notes

- Using a custom render on any of the frontend frameworks will move the client load directive to the root of the "island" tree. See the POC in the Preact playground
- Support for props will be forthcoming. Approach is taken from how Storybook handles Vue stories

## Todo
- [ ] Add tests in the new example sub project
  - [ ] Tests using atoms with nanostores
  - [ ] Custom callbacks passed to components
  - [ ] Mix of decorators and custom rendering
- [ ] Documentation on custom render functions and how they affect decorators 